### PR TITLE
Add License to Gemspec

### DIFF
--- a/mandrill-api-json.gemspec
+++ b/mandrill-api-json.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
     s.name = 'mandrill-api-json'
     s.version = '1.0.56'
@@ -9,4 +11,5 @@ Gem::Specification.new do |s|
     s.homepage = 'https://github.com/atpsoft/mandrill-api-ruby'
     s.add_dependency 'json', '>= 1.7.7', '< 3'
     s.add_dependency 'excon', '>= 0.16.0', '< 1.0'
+    s.license = 'Apache-2.0'
 end


### PR DESCRIPTION
Add license to Gemspec per [ruby specification](https://guides.rubygems.org/specification-reference/#license=). This makes it clear for anyone using this code of the license type. In addition, automated tools like [`license_finder`](https://github.com/pivotal/LicenseFinder) can now detect the license type for this gem.