### PR TITLE
docs/script to download attachments using Mandrill API (test mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,61 @@ gem 'mandrill-api-json'
 ```
 
 and run `bundle install`
+
+### How to check attachments in Test Mode on Mandrill
+
+In order to retrieve Mandrill attachments in test mode the following script can be used:
+
+```ruby
+require 'mandrill'
+require 'base64'
+
+def extract_attachments(email)
+  attachments = []
+
+  email['attachments'].each do |attachment|
+    attachment_data = attachment['content']
+    file_name = attachment['name']
+    content_type = attachment['type']
+
+    # Decode the attachment data from base64
+    decoded_data = Base64.decode64(attachment_data)
+
+    # Save the attachment to a file
+    File.open(file_name, 'wb') do |file|
+      file.write(decoded_data)
+    end
+
+    attachments << {
+      file_name: file_name,
+      content_type: content_type
+    }
+  end
+
+  attachments
+end
+
+# Mandrill API key
+mandrill_api_key = 'YOUR_MANDRILL_API_KEY'
+
+# Mandrill message ID of the delivered email.
+# You can find it in https://mandrillapp.com/settings/api, within the request of the email sent.
+message_id = 'YOUR_DELIVERED_EMAIL_MESSAGE_ID'
+
+# Initialize Mandrill client
+mandrill = Mandrill::API.new(mandrill_api_key)
+
+# Retrieve the message content using Mandrill API
+message_info = mandrill.messages.content(message_id)
+
+# Extract attachments from the message
+attachments = extract_attachments(message_info)
+
+# Print the extracted attachments
+attachments.each do |attachment|
+  puts "Attachment: #{attachment[:file_name]}"
+  puts "Content Type: #{attachment[:content_type]}"
+  puts "---"
+end
+
+```


### PR DESCRIPTION
The following proposed change include a guide on how to download attachments using Mandrill API.
This information is useful when developing and testing emails containing attachments and sent using Mandrill in test mode.

I have spent some time trying to find a solution for this and that is why I am sharing this guide to help others in the future.
I hope it helps.