### PR TITLE
Fix CVE-2026-54171

### DIFF
--- a/mandrill-api-json.gemspec
+++ b/mandrill-api-json.gemspec
@@ -8,5 +8,5 @@ Gem::Specification.new do |s|
     s.files = ['lib/mandrill.rb', 'lib/mandrill/api.rb', 'lib/mandrill/errors.rb']
     s.homepage = 'https://github.com/atpsoft/mandrill-api-ruby'
     s.add_dependency 'json', '>= 1.8'
-    s.add_dependency 'excon', '>= 0.16.0', '< 1.0'
+    s.add_dependency 'excon', '>= 1.5.0'
 end


### PR DESCRIPTION
This updates the required version of the excon gem to 1.5.0 or later. There is a security vulnerability in prior versions of excon.

The API for the `post` method on the Connection object did not change. So no further code changes necessary.